### PR TITLE
test_adopt.py: test_new_module fails locally

### DIFF
--- a/tests/test_adopt.py
+++ b/tests/test_adopt.py
@@ -51,6 +51,7 @@ def test_new_module(tmp_path: Path):
     assert (module / "src" / "my_module").is_dir()
     assert check_output("git", "branch", cwd=module).strip() == "* main"
     check_output("python", "-m", "venv", "venv", cwd=module)
+    check_output("venv/bin/pip", "install", "--upgrade", "pip", cwd=module)
     check_output("venv/bin/pip", "install", ".[dev]", cwd=module)
     check_output(
         "venv/bin/python",


### PR DESCRIPTION
Closes #68

In the test, the version of sphinx used is incompatible with sphinx_design when ran locally.

Ensuring an upgrade to pip inside the test generated pip environment fixes this. The github runner uses an up to date version already which is why it passes.