### PR TITLE
Added references to pre-commit installation

### DIFF
--- a/docs/developer/how-to/lint.rst
+++ b/docs/developer/how-to/lint.rst
@@ -15,6 +15,9 @@ commit`` on just the files that have changed::
 
     $ pre-commit install
 
+It is also possible to `automatically enable pre-commit on cloned repositories <https://pre-commit.com/#automatically-enabling-pre-commit-on-repositories>`_.
+This will result in pre-commits being enabled on every repo your user clones from now on.
+
 Fixing issues
 -------------
 

--- a/docs/user/how-to/existing.rst
+++ b/docs/user/how-to/existing.rst
@@ -20,6 +20,10 @@ This will:
 
     To enable publishing to PyPI see `../how-to/pypi` 
 
+.. note::
+
+    To install the pre-commit see `../../developer/how-to/lint`
+
 Example merge
 -------------
 

--- a/docs/user/tutorials/new.rst
+++ b/docs/user/tutorials/new.rst
@@ -49,6 +49,11 @@ project or github Organization.
 
 see `../how-to/pypi`
 
+Setting up pre-commit
+---------------------
+
+To install the pre-commit see `../../developer/how-to/lint`.
+
 Running the tests
 -----------------
 


### PR DESCRIPTION
Closes #67 

Changes to docs. I thought it made sense to explain the pre-commit process in one place in the docs and reference it elsewhere.

* Added a line in `docs/developer/how-to/lint.rst` suggesting automatically enabling pre-commit on newly cloned repos for the user.
* Added a note in `docs/user/how-to/existing.rst` linking back to `docs/developer/how-to/lint.rst`.
* Added a section in `docs/user/tutorials/new.rst` linking back to `docs/developer/how-to/lint.rst`.