### PR TITLE
Changed to allow the skeleton url to be variable, diamond by default

### DIFF
--- a/docs/user/how-to/existing.rst
+++ b/docs/user/how-to/existing.rst
@@ -4,7 +4,7 @@ How to adopt the skeleton in an existing repo
 If you have an existing repo and would like to adopt the skeleton structure
 then you can use the commandline tool to merge the skeleton into your repo::
 
-    python3-pip-skeleton existing /path/to/existing/repo --org my_github_user_or_org
+    python3-pip-skeleton existing /path/to/existing/repo --org my_github_user_or_org --skeleton-org some_institution
 
 This will:
 
@@ -12,6 +12,7 @@ This will:
 - Take the package name from the repo name unless overridden by ``--package``
 - Clone the existing repo in /tmp
 - Create a new orphan merge branch from the skeleton repo
+- Use the version of the skeleton in ``some_institution``'s organization (default ``DiamondLightSource``)
 - Create a single commit that modifies the skeleton with the repo and package name
 - Push that merge branch back to the existing repo
 - Merge with the currently checked out branch, leaving you to fix the conflicts

--- a/docs/user/how-to/maintain-your-own-skeleton.rst
+++ b/docs/user/how-to/maintain-your-own-skeleton.rst
@@ -1,0 +1,12 @@
+Creating a new skeleton fork
+============================
+
+There may be some features in the DiamondLightSource skeleton which aren't required,
+or some you want to add which Diamond doesn't require. The python3-pip-skeleton can be used
+with any ``https://github.com/SomeInstitution/python3-pip-skeleton`` forked from 
+``https://github.com/DiamondLightSource/python3-pip-skeleton`` by using ``--skeleton-org SomeInstitution``
+when implementing the skeleton on a new or existing repo.
+
+The forked skeleton repo has to have the name ``python3-pip-skeleton``. It can be changed however the 
+institution requires, then DiamondLightSource's skeleton can be periodically pulled from upstream 
+to acquire the latest changes. 

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -26,6 +26,7 @@ side-bar.
             :caption: How-to Guides
             :maxdepth: 1
 
+            how-to/maintain-your-own-skeleton
             how-to/run-container
             how-to/existing
             how-to/update

--- a/docs/user/tutorials/new.rst
+++ b/docs/user/tutorials/new.rst
@@ -1,10 +1,10 @@
 Creating a new repo from the skeleton
 =====================================
 
-Once you have followed the `installation` tutorial, you can use the
+Once you have followed the ``installation`` tutorial, you can use the
 commandline tool to make a new repo that inherits the skeleton::
 
-    python3-pip-skeleton new /path/to/be/created --org my_github_user_or_org
+    python3-pip-skeleton new /path/to/be/created --org my_github_user_or_org --skeleton-org some_institution
 
 This will:
 
@@ -12,6 +12,7 @@ This will:
 - Take the package name from the repo name unless overridden by ``--package``
 - Create a new repo at the requested path, forked from the skeleton repo
 - Create a single commit that modifies the skeleton with the repo and package name
+- Use the version of the skeleton in ``some_institution``'s organization (default ``DiamondLightSource``)
 
 
 Getting started with your new repo

--- a/src/python3_pip_skeleton/__main__.py
+++ b/src/python3_pip_skeleton/__main__.py
@@ -11,17 +11,18 @@ from . import __version__
 
 __all__ = ["main"]
 
-# The source of the skeleton module to pull from
-SKELETON = "https://github.com/DiamondLightSource/python3-pip-skeleton"
+# The url of the default skeleton module to pull from, a different skeleton
+# url can be passed in with --skeleton-git-url
+SKELETON_URL = "https://github.com/%s/python3-pip-skeleton"
 # The name of the merge branch that will be created
 MERGE_BRANCH = "skeleton-merge-branch"
 # Extensions to change
 CHANGE_SUFFIXES = [".py", ".rst", ".cfg", "", ".toml"]
 # Files not to change
 IGNORE_FILES = [
-    "update-tools.rst",
     "test_boilerplate_removed.py",
     "pin-requirements.rst",
+    "update-tools.rst",
 ]
 
 SKELETON_ROOT_COMMIT = "ededf00035e6ccfac78946213009c1ecd7c110a9"
@@ -57,6 +58,7 @@ def merge_skeleton(
     full_name: str,
     email: str,
     from_branch: str,
+    skeleton_org: str,
     package,
 ):
     path = path.resolve()
@@ -70,6 +72,10 @@ def merge_skeleton(
         text = text.replace("email@address.com", email)
         text = text.replace("main", from_branch)
         return text
+
+    def replace_in_file(file_path: Path, text_from: str, text_to: str):
+        file_contents = file_path.read_text()
+        file_path.write_text(file_contents.replace(text_from, text_to))
 
     branches = list_branches(path)
     assert MERGE_BRANCH not in branches, (
@@ -88,7 +94,7 @@ def merge_skeleton(
         # will do the wrong thing
         shutil.rmtree(git_tmp / "src", ignore_errors=True)
         # Merge in the skeleton commits
-        git_tmp("pull", "--rebase=false", SKELETON, from_branch)
+        git_tmp("pull", "--rebase=false", SKELETON_URL % skeleton_org, from_branch)
         # Move things around
         if package != "python3_pip_skeleton":
             git_tmp("mv", "src/python3_pip_skeleton", f"src/{package}")
@@ -98,6 +104,14 @@ def merge_skeleton(
             if child.suffix in CHANGE_SUFFIXES and child.name not in IGNORE_FILES:
                 text = replace_text(child.read_text())
                 child.write_text(text)
+
+        # Change instructions in the docs to reflect which pip skeleton is in use
+        replace_in_file(
+            Path(git_tmp.name) / "docs/developer/how-to/update-tools.rst",
+            "DiamondLightSource",
+            skeleton_org,
+        )
+
         # Commit what we have and push to the original repo
         git_tmp("commit", "-a", "-m", f"Rename python3-pip-skeleton -> {repo}")
         git_tmp("push", "origin", MERGE_BRANCH)
@@ -120,7 +134,7 @@ def validate_package(args) -> str:
     return package
 
 
-def verify_not_adopted(root: Path):
+def verify_not_adopted(root: Path, skeleton_git_url: str):
     """Verify that module has not already adopted skeleton"""
 
     # This call does not print anything - the return code is 0 if it is an ancestor
@@ -138,7 +152,7 @@ def verify_not_adopted(root: Path):
 
     assert not_adopted, (
         f"Package {root} has already adopted skeleton. You can type:\n"
-        f"    git pull --rebase=false {SKELETON}\n"
+        f"    git pull --rebase=false {skeleton_git_url}\n"
         "to update. If there were significant upstream changes a re-adopt may be "
         "better. use the --force flag to the command you just ran."
     )
@@ -163,6 +177,7 @@ def new(args):
         full_name=args.full_name or git("config", "--get", "user.name").strip(),
         email=args.email or git("config", "--get", "user.email").strip(),
         from_branch=args.from_branch or "main",
+        skeleton_org=args.skeleton_org,
         package=package,
     )
 
@@ -183,7 +198,7 @@ def existing(args):
     file_path: Path = path / "setup.cfg"
     assert file_path.is_file(), "Expected a setup.cfg file in the directory."
     if not args.force:
-        verify_not_adopted(args.path)
+        verify_not_adopted(args.path, skeleton_git_url=SKELETON_URL % args.skeleton_org)
 
     conf = ConfigParser()
     conf.read(path / "setup.cfg")
@@ -196,6 +211,7 @@ def existing(args):
         full_name=conf["metadata"]["author"],
         email=conf["metadata"]["author_email"],
         from_branch=args.from_branch or "main",
+        skeleton_org=args.skeleton_org,
         package=package,
     )
 
@@ -219,11 +235,17 @@ def main(args=None):
     parser = ArgumentParser()
     subparsers = parser.add_subparsers()
     parser.add_argument("--version", action="version", version=__version__)
+
     # Add a command for making a new repo
     sub = subparsers.add_parser("new", help="Make a new repo forked from this skeleton")
     sub.set_defaults(func=new)
     sub.add_argument("path", type=Path, help="Path to new repo to create")
     sub.add_argument("--org", required=True, help="GitHub organization for the repo")
+    sub.add_argument(
+        "--skeleton-org",
+        default="DiamondLightSource",
+        help="The organisation of the python3-pip-skeleton to use",
+    )
     sub.add_argument(
         "--package", default=None, help="Package name, defaults to directory name"
     )
@@ -244,6 +266,11 @@ def main(args=None):
     sub.add_argument("path", type=Path, help="Path to new repo to existing repo")
     sub.add_argument("--force", action="store_true", help="force readoption")
     sub.add_argument("--org", required=True, help="GitHub organization for the repo")
+    sub.add_argument(
+        "--skeleton-org",
+        default="DiamondLightSource",
+        help="The organisation of the python3-pip-skeleton to use",
+    )
     sub.add_argument(
         "--package", default=None, help="Package name, defaults to directory name"
     )


### PR DESCRIPTION
Closes #73 
The skeleton used now defaults to the url `DEFAULT_SKELETON_URL = "https://github.com/DiamondLightSource/python3-pip-skeleton"` , though a different url can be passed in with the `--skeleton-git-url` argument.

`updating-tools.rst` has been removed from the `IGNORE_FILES`, and so links containing "DiamondLightSource"  will be changed to  have whatever org was passed in by `--org`..