### PR TITLE
python3-pip-skeleton with no arguments now returns help

### DIFF
--- a/src/python3_pip_skeleton/__main__.py
+++ b/src/python3_pip_skeleton/__main__.py
@@ -264,7 +264,7 @@ def main(args=None):
     args = parser.parse_args(args)
     if len(sys.argv) == 1:
         parser.print_help()
-        sys.exit(2)
+        sys.exit()
     args.func(args)
 
 

--- a/src/python3_pip_skeleton/__main__.py
+++ b/src/python3_pip_skeleton/__main__.py
@@ -1,5 +1,6 @@
 import re
 import shutil
+import sys
 from argparse import ArgumentParser
 from configparser import ConfigParser
 from pathlib import Path
@@ -261,6 +262,9 @@ def main(args=None):
     sub.add_argument("path", type=Path, help="Path to existing repo with skeleton code")
     # Parse args and run
     args = parser.parse_args(args)
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(2)
     args.func(args)
 
 

--- a/tests/test_adopt.py
+++ b/tests/test_adopt.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 from os import makedirs
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import toml
@@ -21,6 +22,13 @@ def check_output(*args, cwd=None) -> str:
 def test_cli_version():
     output = check_output(sys.executable, "-m", "python3_pip_skeleton", "--version")
     assert output.strip() == __version__
+
+
+@patch("python3_pip_skeleton.__main__.ArgumentParser.print_help")
+def test_cli_no_arguments(mocked_print_help):
+    with pytest.raises(SystemExit):
+        __main__.main()
+    assert mocked_print_help.called
 
 
 def test_new_module(tmp_path: Path):


### PR DESCRIPTION
python3-pip-skeleton with no arguments now prints help.  resolves #79 